### PR TITLE
Fix hashflag size and position

### DIFF
--- a/main.css
+++ b/main.css
@@ -83,6 +83,11 @@ img.Emoji {
   width: 20px;
 }
 
+img.twitter-hashflag {
+	max-height: 12px;
+	padding-left: 3px;
+}
+
 .attribution p {
 	color: white;
 	font-size: 14px;

--- a/main.css
+++ b/main.css
@@ -85,6 +85,7 @@ img.Emoji {
 
 img.twitter-hashflag {
 	max-height: 12px;
+	max-width: 12px;
 	padding-left: 3px;
 }
 


### PR DESCRIPTION
Hashflags currently show at full width, which causes a pixelated image. This CSS fixes that and keeps them styled more like Twitter.com, next to the hashtag.

Current Display:
<img width="568" alt="screen shot 2017-03-13 at 3 10 44 pm" src="https://cloud.githubusercontent.com/assets/1407140/23871187/bb7a50d4-07ff-11e7-9cdc-b1136ca90e05.png">
